### PR TITLE
Fix gcp_has_credentials_file field type

### DIFF
--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -277,7 +277,7 @@ message CollectorConfig {
 
   string gcp_cloudsql_instance_id = 69;
   string gcp_pubsub_subscription = 70;
-  string gcp_has_credentials_file = 71;
+  bool gcp_has_credentials_file = 71;
   string gcp_project_id = 72;
 
   string api_system_id = 82;


### PR DESCRIPTION
We were not using this field before and I don't imagine anyone else is either so I think it's okay to change it, but lmk if you want to drop the old field and add a new one instead.