### PR TITLE
Add fields for reporting disabled log collection

### DIFF
--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -30,6 +30,8 @@ message FullSnapshot {
   string collector_platform_version = 28;
   string collector_virtualization_system = 29; // Name of the virtualization system (only if we're a guest)
   string collector_kernel_version = 30;
+  bool collector_log_snapshot_disabled = 31;
+  string collector_log_snapshot_disabled_reason = 32;
 
   // Per server (and hence snapshot)
   System system = 100;


### PR DESCRIPTION
Add fields for reporting when log collection has been disabled

Some settings usually cause a drastic increase in log volume and are
not supported.