### PR TITLE
Log Insights: Add support for inconsistent range bounds error

### DIFF
--- a/compact_log_snapshot.proto
+++ b/compact_log_snapshot.proto
@@ -196,6 +196,7 @@ message LogLineInformation {
     INVALID_BYTE_SEQUENCE = 137; // "invalid byte sequence for encoding"
     COULD_NOT_SERIALIZE_REPEATABLE_READ = 138; // "could not serialize access due to concurrent update"
     COULD_NOT_SERIALIZE_SERIALIZABLE = 139; // "could not serialize access due to read/write dependencies among transactions"
+    INCONSISTENT_RANGE_BOUNDS = 140; // "range lower bound must be less than or equal to range upper bound"
 
     // Collector internal events
     PGA_COLLECTOR_IDENTIFY = 1000; // "pganalyze-collector-identify: server1"


### PR DESCRIPTION
Example:

ERROR: range lower bound must be less than or equal to range upper bound