### PR TITLE
Make the custom type domain_constraint field an array

### DIFF
--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -520,9 +520,10 @@ message CustomTypeInformation {
   string domain_type = 5;
   bool domain_not_null = 6;
   string domain_default = 7;
-  string domain_constraint = 8;
+  string domain_constraint = 8; // deprecated in favor of domain_constraints, field 11
   repeated string enum_values = 9;
   repeated CompositeAttr composite_attrs = 10;
+  repeated string domain_constraints = 11;
 
   enum Type {
     ENUM = 0;


### PR DESCRIPTION
Currently we assume domains can have only one constraint, but this is
not the case.

Support recording multiple domain constraints.
