### PR TITLE
Add blocking info to backend

### DIFF
--- a/compact_activity_snapshot.proto
+++ b/compact_activity_snapshot.proto
@@ -322,7 +322,7 @@ message Backend {
   string wait_event = 20;
   string backend_type = 21;
 
-  repeated int64 blocked_by_pids = 22;
+  repeated int32 blocked_by_pids = 22;
 }
 
 message VacuumProgressInformation {

--- a/compact_activity_snapshot.proto
+++ b/compact_activity_snapshot.proto
@@ -321,6 +321,8 @@ message Backend {
   string wait_event_type = 19;
   string wait_event = 20;
   string backend_type = 21;
+
+  repeated int64 blocked_by_pids = 22;
 }
 
 message VacuumProgressInformation {


### PR DESCRIPTION
Adding the information about locking to snapshot. `blocked_by_pids` is the list of pids that this backend is blocked by.

This is an alternate version of https://github.com/pganalyze/collector-snapshot/pull/24.