### PR TITLE
Add non-frequently updated schema table stats

### DIFF
--- a/compact_system_snapshot.proto
+++ b/compact_system_snapshot.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/timestamp.proto";
-
 import "shared.proto";
 
 package pganalyze.collector;

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -480,11 +480,11 @@ message RelationStatistic {
   int32 frozenxid_age = 30; // The age of frozen xact ID for this relation (relative to latest stable xid)
   int32 minmxid_age = 31; // The age of minimum multixact ID for this relation (relative to latest stable mxid)
 
-  // For infrequently updated stats
+  // Statistics that are infrequently updated (e.g. by VACUUM, ANALYZE, and a few DDL commands)
   int32 relpages = 40;                 // Size of the on-disk representation of this table in pages (of size BLCKSZ)
-  int64 reltuples = 41;                // Number of live rows in the table. -1 indicating that the row count is unknown
+  float reltuples = 41;                // Number of live rows in the table. -1 indicating that the row count is unknown
   int32 relallvisible = 42;            // Number of pages that are marked all-visible in the table's visibility map
-  int32 relfrozenxid = 43;             // All transaction IDs before this one have been replaced with a permanent (“frozen”) transaction ID in this table
+  int64 relfrozenxid = 43;             // All transaction IDs before this one have been replaced with a permanent (“frozen”) transaction ID in this table, in xid8 (64-bit FullTransactionId)
   int32 relminmxid = 44;               // All multixact IDs before this one have been replaced by a transaction ID in this table
   NullTimestamp last_vacuum = 45;      // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
   NullTimestamp last_autovacuum = 46;  // Last time at which this table was vacuumed by the autovacuum daemon

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -485,7 +485,7 @@ message RelationStatistic {
   float reltuples = 41;                // Number of live rows in the table. -1 indicating that the row count is unknown
   int32 relallvisible = 42;            // Number of pages that are marked all-visible in the table's visibility map
   int64 relfrozenxid = 43;             // All transaction IDs before this one have been replaced with a permanent (“frozen”) transaction ID in this table, in xid8 (64-bit FullTransactionId)
-  int32 relminmxid = 44;               // All multixact IDs before this one have been replaced by a transaction ID in this table
+  int64 relminmxid = 44;               // All multixact IDs before this one have been replaced by a transaction ID in this table
   NullTimestamp last_vacuum = 45;      // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
   NullTimestamp last_autovacuum = 46;  // Last time at which this table was vacuumed by the autovacuum daemon
   NullTimestamp last_analyze = 47;     // Last time at which this table was manually analyzed

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -479,6 +479,15 @@ message RelationStatistic {
 
   int32 frozenxid_age = 30; // The age of frozen xact ID for this relation (relative to latest stable xid)
   int32 minmxid_age = 31; // The age of minimum multixact ID for this relation (relative to latest stable mxid)
+
+  // For infrequently updated stats
+  int32 relpages = 40;                 // Size of the on-disk representation of this table in pages (of size BLCKSZ)
+  int64 reltuples = 41;                // Number of live rows in the table. -1 indicating that the row count is unknown
+  int32 relallvisible = 42;            // Number of pages that are marked all-visible in the table's visibility map
+  NullTimestamp last_vacuum = 43;      // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
+  NullTimestamp last_autovacuum = 44;  // Last time at which this table was vacuumed by the autovacuum daemon
+  NullTimestamp last_analyze = 45;     // Last time at which this table was manually analyzed
+  NullTimestamp last_autoanalyze = 46; // Last time at which this table was analyzed by the autovacuum daemon
 }
 
 message RelationEvent {

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -484,10 +484,12 @@ message RelationStatistic {
   int32 relpages = 40;                 // Size of the on-disk representation of this table in pages (of size BLCKSZ)
   int64 reltuples = 41;                // Number of live rows in the table. -1 indicating that the row count is unknown
   int32 relallvisible = 42;            // Number of pages that are marked all-visible in the table's visibility map
-  NullTimestamp last_vacuum = 43;      // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
-  NullTimestamp last_autovacuum = 44;  // Last time at which this table was vacuumed by the autovacuum daemon
-  NullTimestamp last_analyze = 45;     // Last time at which this table was manually analyzed
-  NullTimestamp last_autoanalyze = 46; // Last time at which this table was analyzed by the autovacuum daemon
+  int32 relfrozenxid = 43;             // All transaction IDs before this one have been replaced with a permanent (“frozen”) transaction ID in this table
+  int32 relminmxid = 44;               // All multixact IDs before this one have been replaced by a transaction ID in this table
+  NullTimestamp last_vacuum = 45;      // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
+  NullTimestamp last_autovacuum = 46;  // Last time at which this table was vacuumed by the autovacuum daemon
+  NullTimestamp last_analyze = 47;     // Last time at which this table was manually analyzed
+  NullTimestamp last_autoanalyze = 48; // Last time at which this table was analyzed by the autovacuum daemon
 }
 
 message RelationEvent {

--- a/vacuum_report.proto
+++ b/vacuum_report.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/timestamp.proto";
 import "shared.proto";
 
 package pganalyze.collector;


### PR DESCRIPTION
Pairing collector side PR: https://github.com/pganalyze/collector/pull/350

We would like to collect more data around schema table stats (`RelationStatistic`) so that we can use it in pganalyze app side. Specifically, we would like to have:

* relpages
* reltuples
* relallvisible

The vacuum/analyze data is currently sent out already in the different shape (with `RelationEvent`), but adding this in the `RelationStatistic` message too, so that we can manipulate them easily in the receiver side.

Also removed unnecessary imports as it's been causing some warning while running the `protoc`.