### PR TITLE
Deprecate old xid and mxid fields

### DIFF
--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -400,8 +400,8 @@ message RelationInformation {
   bool has_inheritance_children = 9;
   bool has_toast = 10;
 
-  uint32 frozen_xid = 11; // deprecated in favor of relfrozenxid in RelationStatistic
-  uint32 minimum_multixact_xid = 12; // deprecated in favor of relminmxid in RelationStatistic
+  reserved 11; // frozen_xid, deprecated in favor of relfrozenxid in RelationStatistic
+  reserved 12; // minimum_multixact_xid, deprecated in favor of relminmxid in RelationStatistic
 
   // True if another process is currently holding an AccessExclusiveLock on this
   // relation, this also means we won't have columns/index/constraints information

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -580,7 +580,7 @@ message CustomTypeInformation {
   string domain_type = 5;
   bool domain_not_null = 6;
   string domain_default = 7;
-  string domain_constraint = 8; // deprecated in favor of domain_constraints, field 11
+  reserved 8; // domain_constraint, deprecated in favor of domain_constraints, field 11
   repeated string enum_values = 9;
   repeated CompositeAttr composite_attrs = 10;
   repeated string domain_constraints = 11;

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -400,8 +400,8 @@ message RelationInformation {
   bool has_inheritance_children = 9;
   bool has_toast = 10;
 
-  uint32 frozen_xid = 11;
-  uint32 minimum_multixact_xid = 12;
+  uint32 frozen_xid = 11; // deprecated in favor of relfrozenxid in RelationStatistic
+  uint32 minimum_multixact_xid = 12; // deprecated in favor of relminmxid in RelationStatistic
 
   // True if another process is currently holding an AccessExclusiveLock on this
   // relation, this also means we won't have columns/index/constraints information


### PR DESCRIPTION
These have effectively been replaced by relfrozenxid and relminmxid in
RelationStatistic.

See #27