### PR TITLE
Add explicit go_package names to fix protoc generation error

### DIFF
--- a/bloat_report.proto
+++ b/bloat_report.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message BloatReportData {
   repeated DatabaseReference database_references = 10;

--- a/buffercache_report.proto
+++ b/buffercache_report.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message BuffercacheReportData {
   repeated DatabaseReference database_references = 10;

--- a/compact_activity_snapshot.proto
+++ b/compact_activity_snapshot.proto
@@ -4,6 +4,7 @@ import "google/protobuf/timestamp.proto";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message CompactActivitySnapshot {
   PostgresVersion postgres_version = 1;

--- a/compact_log_snapshot.proto
+++ b/compact_log_snapshot.proto
@@ -4,6 +4,7 @@ import "google/protobuf/timestamp.proto";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message CompactLogSnapshot {
   repeated LogFileReference log_file_references = 1;

--- a/compact_snapshot.proto
+++ b/compact_snapshot.proto
@@ -8,6 +8,7 @@ import "compact_system_snapshot.proto";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 // Format Version: 1.0.0
 

--- a/compact_system_snapshot.proto
+++ b/compact_system_snapshot.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message CompactSystemSnapshot {
   System system = 1;

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -4,6 +4,7 @@ import "google/protobuf/timestamp.proto";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 // Format Version: 1.0.0
 

--- a/report.proto
+++ b/report.proto
@@ -8,6 +8,7 @@ import "vacuum_report.proto";
 import "sequence_report.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message Report {
   string report_run_id = 1;

--- a/sequence_report.proto
+++ b/sequence_report.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message SequenceReportData {
   repeated DatabaseReference database_references = 10;

--- a/shared.proto
+++ b/shared.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message NullString {
   bool valid = 1;

--- a/vacuum_report.proto
+++ b/vacuum_report.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "shared.proto";
 
 package pganalyze.collector;
+option go_package = "github.com/pganalyze/collector/output/pganalyze_collector";
 
 message VacuumReportData {
   repeated DatabaseReference database_references = 10;


### PR DESCRIPTION
This is now required by upstream's protoc compiler, and the alternative (passing an explicit -M flag to the protoc invocation) is more frustrating to implement, since it needs to be done once for each file.

See https://protobuf.dev/reference/go/go-generated/