### PR TITLE
Add extended statistics (CREATE STATISTICS) information

### DIFF
--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -430,6 +430,8 @@ message RelationInformation {
 
   NullString toast_name = 21;
 
+  repeated ExtendedStatistic extended_stats = 22;
+
   message Column {
     string name = 2;
     string data_type = 3;
@@ -459,6 +461,21 @@ message RelationInformation {
     string foreign_update_type = 7;     // Foreign key update action code: a = no action, r = restrict, c = cascade, n = set null, d = set default
     string foreign_delete_type = 8;     // Foreign key deletion action code: a = no action, r = restrict, c = cascade, n = set null, d = set default
     string foreign_match_type = 9;      // Foreign key match type: f = full, p = partial, s = simple
+  }
+
+  // TODO: Should this be its own top-level item, with a reference back to the relation? (also possibly split this in reference, information and stats?)
+  message ExtendedStatistic {
+    string statistics_schema = 1;    // Schema this statistics object is located in (may be different than the table's schema)
+    string statistics_name = 2;      // Name of the statistics object (must be unique within the schema)
+    repeated int32 columns = 3;      // Columns that are analyzed for this statistics object
+    repeated string expressions = 4; // Expressions (represented as SQL) that are analyzed for this statistics object
+    repeated string kind = 5;        // Enabled statistics kinds: d = n-distinct statistics, f = functional dependency statistics, m = most common values (MCV) list statistics, e = expression statistics
+    bool has_data = 6;               // Whether data was retrieved successfully - ANALYZE must have been run, and we must have had enough permissions to read data
+
+    // Fields only set when data was retrieved successfully
+    bool inherited = 10;
+    NullString n_distinct = 11;
+    NullString dependencies = 12;
   }
 }
 

--- a/full_snapshot.proto
+++ b/full_snapshot.proto
@@ -463,7 +463,6 @@ message RelationInformation {
     string foreign_match_type = 9;      // Foreign key match type: f = full, p = partial, s = simple
   }
 
-  // TODO: Should this be its own top-level item, with a reference back to the relation? (also possibly split this in reference, information and stats?)
   message ExtendedStatistic {
     string statistics_schema = 1;    // Schema this statistics object is located in (may be different than the table's schema)
     string statistics_name = 2;      // Name of the statistics object (must be unique within the schema)


### PR DESCRIPTION
The [extended statistics](https://www.postgresql.org/docs/current/planner-stats.html#PLANNER-STATS-EXTENDED) are used to instruct the server to obtain statistics across interesting sets of columns.

The statistic is unique by the schema name + the statistic name, can be (currently) created for the one particular table. Since the statistic will be created per table, and one table can have many statistics, it makes sense to have this under the `RelationInformation`, as repeated object.

You can create the extended statistic within the different schema from the table's schema, which can be a bit confusing as the data model, but the schema name here is pretty much only used to make it unique, so I think it's fine to just send/store it as a string name.