### PR TITLE
Add system info for Crunchy Bridge

### DIFF
--- a/shared.proto
+++ b/shared.proto
@@ -136,6 +136,7 @@ message SystemInformation {
   oneof info {
     SystemInformationSelfHosted self_hosted = 2;
     SystemInformationAmazonRDS amazon_rds = 3;
+    SystemInformationCrunchyBridge crunchy_bridge = 5;
   }
 
   map<string, string> resource_tags = 4;
@@ -185,6 +186,17 @@ message SystemInformationAmazonRDS {
   bool parameter_auto_explain_enabled = 42;
 
   bool is_aurora_postgres = 50;
+}
+
+message SystemInformationCrunchyBridge {
+  string cluster_name = 1;
+  google.protobuf.Timestamp created_at = 2;
+  string plan_id = 3;
+  string provider_id = 4;
+  string region_id = 5;
+  int32 cpu_units = 6;
+  int32 storage_gb = 7;
+  double memory_gb = 8;
 }
 
 message SchedulerStatistic {


### PR DESCRIPTION
This PR allows the collector to pass some Crunchy Bridge system info data to pganalyze, so that we can show these info in the pganalyze side's System Overview page.
This contains enough basic data to show what we can see in Crunchy side's dashboard, which would be a good start:

![image](https://github.com/pganalyze/collector-snapshot/assets/911433/39244152-5bb3-4398-88fe-eac5d2fcb84d)
